### PR TITLE
Typed error handling

### DIFF
--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -10,7 +10,7 @@ pub struct IpInfo {
 fn main() {
     let mut app = App::new();
     app.add_plugins((MinimalPlugins, HttpClientPlugin))
-        .add_systems(Update, handle_response)
+        .add_systems(Update, (handle_response, handle_error))
         .add_systems(
             Update,
             send_request.run_if(on_timer(std::time::Duration::from_secs(1))),
@@ -30,5 +30,11 @@ fn send_request(mut ev_request: EventWriter<TypedRequest<IpInfo>>) {
 fn handle_response(mut ev_response: EventReader<TypedResponse<IpInfo>>) {
     for response in ev_response.read() {
         println!("ip: {}", response.ip);
+    }
+}
+
+fn handle_error(mut ev_error: EventReader<TypedResponseError<IpInfo>>) {
+    for error in ev_error.read() {
+        println!("Error retrieving IP: {}", error.err);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,7 +458,15 @@ pub struct HttpResponse(pub Response);
 
 /// wrap for ehttp error
 #[derive(Event, Debug, Clone, Deref)]
-pub struct HttpResponseError(pub String);
+pub struct HttpResponseError {
+    pub err: String,
+}
+
+impl HttpResponseError {
+    pub fn new(err: String) -> Self {
+        Self { err }
+    }
+}
 
 /// task for ehttp response result
 #[derive(Component)]
@@ -495,7 +503,7 @@ fn handle_request(
                             world
                                 .get_resource_mut::<Events<HttpResponseError>>()
                                 .unwrap()
-                                .send(HttpResponseError(e.to_string()));
+                                .send(HttpResponseError::new(e.to_string()));
                         }
                     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use super::typed::{HttpTypedRequestTrait, TypedRequest, TypedResponse};
+pub use super::typed::{HttpTypedRequestTrait, TypedRequest, TypedResponse, TypedResponseError};
 pub use super::{
     HttpClient, HttpClientPlugin, HttpClientSetting, HttpRequest, HttpResponse, HttpResponseError,
     RequestTask,

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -108,8 +108,9 @@ where
     inner: T,
 }
 
-#[derive(Event, Debug, Clone)]
+#[derive(Event, Debug, Clone, Deref)]
 pub struct TypedResponseError<T> {
+    #[deref]
     pub err: String,
     phantom: PhantomData<T>,
 }

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,4 +1,4 @@
-use crate::{HttpClientSetting, HttpResponseError, RequestTask};
+use crate::{HttpClientSetting, RequestTask};
 use bevy::app::{App, PreUpdate};
 use bevy::ecs::system::CommandQueue;
 use bevy::hierarchy::DespawnRecursiveExt;
@@ -37,6 +37,7 @@ impl HttpTypedRequestTrait for App {
     ) -> &mut Self {
         self.add_event::<TypedRequest<T>>();
         self.add_event::<TypedResponse<T>>();
+        self.add_event::<TypedResponseError<T>>();
         self.add_systems(PreUpdate, handle_typed_request::<T>);
         self
     }
@@ -107,6 +108,21 @@ where
     inner: T,
 }
 
+#[derive(Event, Debug, Clone)]
+pub struct TypedResponseError<T> {
+    pub err: String,
+    phantom: PhantomData<T>,
+}
+
+impl<T> TypedResponseError<T> {
+    pub fn new(err: String) -> Self {
+        Self {
+            err,
+            phantom: Default::default(),
+        }
+    }
+}
+
 /// A system that handles typed HTTP requests.
 fn handle_typed_request<T: for<'a> Deserialize<'a> + Send + Sync + 'static>(
     mut commands: Commands,
@@ -130,20 +146,30 @@ fn handle_typed_request<T: for<'a> Deserialize<'a> + Send + Sync + 'static>(
                 command_queue.push(move |world: &mut World| {
                     match response {
                         Ok(res) => {
-                            serde_json::from_slice(res.bytes.as_slice())
-                                .map(|inner| {
+                            let res: Result<T, _> = serde_json::from_slice(res.bytes.as_slice());
+
+                            match res {
+                                // deserialize success, send response
+                                Ok(inner) => {
                                     world
                                         .get_resource_mut::<Events<TypedResponse<T>>>()
                                         .unwrap()
                                         .send(TypedResponse { inner });
-                                })
-                                .expect("Failed to deserialize response");
+                                }
+                                // deserialize error, send error
+                                Err(e) => {
+                                    world
+                                        .get_resource_mut::<Events<TypedResponseError<T>>>()
+                                        .unwrap()
+                                        .send(TypedResponseError::new(e.to_string()));
+                                }
+                            }
                         }
                         Err(e) => {
                             world
-                                .get_resource_mut::<Events<HttpResponseError>>()
+                                .get_resource_mut::<Events<TypedResponseError<T>>>()
                                 .unwrap()
-                                .send(HttpResponseError(e.to_string()));
+                                .send(TypedResponseError::new(e.to_string()));
                         }
                     }
 


### PR DESCRIPTION
builds on #2 from @Leinnan 

prevents panic when receiving malformed data, allows user handling of errors

**breaking:** changes the structure of `HttpResponseError` for parity with the new `TypedResponseError` (it needed phantom data and an extra field for the http response)

adds error handling to the `typed` example