### PR TITLE
Fix bevy SemVer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy", "http", "plugin", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.13.0", default-features = false, features = ["multi-threaded"] }
+bevy = { version = "0.13", default-features = false, features = ["multi-threaded"] }
 crossbeam-channel = "0.5.11"
 ehttp = { version = "0.5.0", features = ["native-async", "json"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Current `Cargo.toml` requires:
`bevy = { version = "0.13.0", default-features = false, features = ["multi-threaded"] }`
This should be:
`bevy = { version = "0.13", default-features = false, features = ["multi-threaded"] }`
So that this package will continue to be compatible with any minor bug fixes during the `0.13` release cycle