### PR TITLE
Prepare examples for 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["bevy", "http", "plugin", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = {git = "https://github.com/bevyengine/bevy"}
-bevy_derive = {git = "https://github.com/bevyengine/bevy"}
-bevy_hierarchy = {git = "https://github.com/bevyengine/bevy"}
-bevy_ecs = { git = "https://github.com/bevyengine/bevy", features = ["multi_threaded"] }
-bevy_tasks = {git = "https://github.com/bevyengine/bevy"}
+bevy_app = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
+bevy_derive = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
+bevy_hierarchy = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
+bevy_ecs = { git = "https://github.com/bevyengine/bevy", rev = "9930df8", features = ["multi_threaded"] }
+bevy_tasks = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
 
 crossbeam-channel = "0.5.11"
 ehttp = { version = "0.5.0", features = ["native-async", "json"] }
@@ -27,7 +27,7 @@ serde_json = "1.0"
 doctest = false
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", rev = "9930df8", default-features = false, features = [
     "animation",
     "bevy_asset",
     "bevy_gilrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["bevy", "http", "plugin", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
-bevy_derive = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
-bevy_hierarchy = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
-bevy_ecs = { git = "https://github.com/bevyengine/bevy", rev = "9930df8", features = ["multi_threaded"] }
-bevy_tasks = {git = "https://github.com/bevyengine/bevy", rev = "9930df8"}
+bevy_app = "0.15.0-rc.1"
+bevy_derive = "0.15.0-rc.1"
+bevy_hierarchy = "0.15.0-rc.1"
+bevy_ecs = { version = "0.15.0-rc.1", features = ["multi_threaded"] }
+bevy_tasks = "0.15.0-rc.1"
 
 crossbeam-channel = "0.5.11"
 ehttp = { version = "0.5.0", features = ["native-async", "json"] }
@@ -27,7 +27,7 @@ serde_json = "1.0"
 doctest = false
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev = "9930df8", default-features = false, features = [
+bevy = { version = "0.15.0-rc.1", default-features = false, features = [
     "animation",
     "bevy_asset",
     "bevy_gilrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["bevy", "http", "plugin", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = "0.14.0"
-bevy_derive = "0.14.0"
-bevy_hierarchy = "0.14.0"
-bevy_ecs = { version = "0.14.0", features = ["multi_threaded"] }
-bevy_tasks = "0.14.0"
+bevy_app = {git = "https://github.com/bevyengine/bevy"}
+bevy_derive = {git = "https://github.com/bevyengine/bevy"}
+bevy_hierarchy = {git = "https://github.com/bevyengine/bevy"}
+bevy_ecs = { git = "https://github.com/bevyengine/bevy", features = ["multi_threaded"] }
+bevy_tasks = {git = "https://github.com/bevyengine/bevy"}
 
 crossbeam-channel = "0.5.11"
 ehttp = { version = "0.5.0", features = ["native-async", "json"] }
@@ -27,7 +27,7 @@ serde_json = "1.0"
 doctest = false
 
 [dev-dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
     "animation",
     "bevy_asset",
     "bevy_gilrs",

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -48,37 +48,34 @@ fn setup(mut commands: Commands) {
                 display: Display::Grid,
                 ..default()
             },
-            ZIndex(i32::MAX), 
+            ZIndex(i32::MAX),
             BackgroundColor(Color::BLACK.with_alpha(0.75)),
-        )).with_children(|parent| {
+        ))
+        .with_children(|parent| {
             let text_font = TextFont {
                 font_size: 40.,
                 ..default()
-            };  
+            };
             parent.spawn(Node::default()).with_children(|parent| {
                 parent.spawn((
-                    Text::new("Status: "), 
-                    TextColor(LIME.into()), 
+                    Text::new("Status: "),
+                    TextColor(LIME.into()),
                     text_font.clone(),
                 ));
                 parent.spawn((
-                    Text::new(""), 
-                    TextColor(AQUA.into()), 
-                    text_font.clone(), 
-                    ResponseText
+                    Text::new(""),
+                    TextColor(AQUA.into()),
+                    text_font.clone(),
+                    ResponseText,
                 ));
             });
             parent.spawn(Node::default()).with_children(|parent| {
+                parent.spawn((Text::new("Ip: "), TextColor(LIME.into()), text_font.clone()));
                 parent.spawn((
-                    Text::new("Ip: "), 
-                    TextColor(LIME.into()), 
-                    text_font.clone()
-                ));
-                parent.spawn((
-                    Text::new(""), 
-                    TextColor(AQUA.into()), 
-                    text_font.clone(), 
-                    ResponseIP
+                    Text::new(""),
+                    TextColor(AQUA.into()),
+                    text_font.clone(),
+                    ResponseIP,
                 ));
             });
         });

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -9,7 +9,6 @@ use bevy_http_client::{
 
 fn main() {
     App::new()
-        .insert_resource(Msaa::Off)
         .insert_resource(ClearColor(Color::srgb(0.4, 0.4, 0.4)))
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
@@ -35,69 +34,56 @@ fn main() {
 #[derive(Component)]
 struct ResponseText;
 
+#[derive(Component)]
+struct ResponseIP;
+
 fn setup(mut commands: Commands) {
     // Camera
-    commands.spawn((Camera2dBundle::default(), IsDefaultUiCamera));
-
-    let text_section = move |color: Srgba, value: &str| {
-        TextSection::new(
-            value,
-            TextStyle {
-                font_size: 40.0,
-                color: color.into(),
-                ..default()
-            },
-        )
-    };
-
+    commands.spawn((Camera2d, IsDefaultUiCamera));
     commands
-        .spawn(NodeBundle {
-            style: Style {
+        .spawn((
+            Node {
                 position_type: PositionType::Absolute,
                 padding: UiRect::all(Val::Px(5.0)),
+                display: Display::Grid,
                 ..default()
-            },
-            z_index: ZIndex::Global(i32::MAX),
-            background_color: Color::BLACK.with_alpha(0.75).into(),
-            ..default()
-        })
-        .with_children(|c| {
-            c.spawn((
-                TextBundle::from_sections([
-                    text_section(LIME, "Status: "),
-                    text_section(AQUA, ""),
-                    text_section(LIME, "\nIp: "),
-                    text_section(AQUA, ""),
-                ]),
-                ResponseText,
-            ));
+            }, 
+            ZIndex(i32::MAX), 
+            BackgroundColor(Color::BLACK.with_alpha(0.75)),
+        )).with_children(|parent| {
+            parent.spawn(Node::default()).with_children(|parent| {
+                parent.spawn((Text::new("Status: "), TextColor(LIME.into())));
+                parent.spawn((Text::new(""), TextColor(AQUA.into()), ResponseText));
+            });
+            parent.spawn(Node::default()).with_children(|parent| {
+                parent.spawn((Text::new("Ip: "), TextColor(LIME.into())));
+                parent.spawn((Text::new(""), TextColor(AQUA.into()) , ResponseIP));
+            });
         });
 }
 
 fn send_request(
     mut ev_request: EventWriter<HttpRequest>,
-    mut query: Query<&mut Text, With<ResponseText>>,
+    mut body_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
+    mut ip_query: Query<&mut Text, (With<ResponseIP>, Without<ResponseText>)>,
 ) {
-    let mut text = query.single_mut();
-    text.sections[1].value = "Requesting".to_string();
-    text.sections[3].value = "".to_string();
+    body_query.single_mut().0 = "Requesting ".to_string();
+    ip_query.single_mut().0 = "".to_string();
     let request = HttpClient::new().get("https://api.ipify.org").build();
     ev_request.send(request);
 }
 
 fn handle_response(
     mut ev_resp: EventReader<HttpResponse>,
-    mut query: Query<&mut Text, With<ResponseText>>,
+    mut body_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
+    mut ip_query: Query<&mut Text, (With<ResponseIP>, Without<ResponseText>)>,
 ) {
     for response in ev_resp.read() {
-        let mut text = query.single_mut();
         let ip = response.text().unwrap_or_default();
-
-        text.sections[1].value = "Got ".to_string();
-        text.sections[3].value = ip.to_string();
+        ip_query.single_mut().0 = ip.to_string();
+        body_query.single_mut().0 = "Got ".to_string();
     }
 }
-
 fn handle_error(mut ev_error: EventReader<HttpResponseError>) {
     for error in ev_error.read() {
         println!("Error retrieving IP: {}", error.err);

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -64,10 +64,10 @@ fn setup(mut commands: Commands) {
 
 fn send_request(
     mut ev_request: EventWriter<HttpRequest>,
-    mut body_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
+    mut status_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
     mut ip_query: Query<&mut Text, (With<ResponseIP>, Without<ResponseText>)>,
 ) {
-    body_query.single_mut().0 = "Requesting ".to_string();
+    status_query.single_mut().0 = "Requesting ".to_string();
     ip_query.single_mut().0 = "".to_string();
     let request = HttpClient::new().get("https://api.ipify.org").build();
     ev_request.send(request);
@@ -75,13 +75,13 @@ fn send_request(
 
 fn handle_response(
     mut ev_resp: EventReader<HttpResponse>,
-    mut body_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
+    mut status_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
     mut ip_query: Query<&mut Text, (With<ResponseIP>, Without<ResponseText>)>,
 ) {
     for response in ev_resp.read() {
         let ip = response.text().unwrap_or_default();
         ip_query.single_mut().0 = ip.to_string();
-        body_query.single_mut().0 = "Got ".to_string();
+        status_query.single_mut().0 = "Got ".to_string();
     }
 }
 fn handle_error(mut ev_error: EventReader<HttpResponseError>) {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -47,17 +47,39 @@ fn setup(mut commands: Commands) {
                 padding: UiRect::all(Val::Px(5.0)),
                 display: Display::Grid,
                 ..default()
-            }, 
+            },
             ZIndex(i32::MAX), 
             BackgroundColor(Color::BLACK.with_alpha(0.75)),
         )).with_children(|parent| {
+            let text_font = TextFont {
+                font_size: 40.,
+                ..default()
+            };  
             parent.spawn(Node::default()).with_children(|parent| {
-                parent.spawn((Text::new("Status: "), TextColor(LIME.into())));
-                parent.spawn((Text::new(""), TextColor(AQUA.into()), ResponseText));
+                parent.spawn((
+                    Text::new("Status: "), 
+                    TextColor(LIME.into()), 
+                    text_font.clone(),
+                ));
+                parent.spawn((
+                    Text::new(""), 
+                    TextColor(AQUA.into()), 
+                    text_font.clone(), 
+                    ResponseText
+                ));
             });
             parent.spawn(Node::default()).with_children(|parent| {
-                parent.spawn((Text::new("Ip: "), TextColor(LIME.into())));
-                parent.spawn((Text::new(""), TextColor(AQUA.into()) , ResponseIP));
+                parent.spawn((
+                    Text::new("Ip: "), 
+                    TextColor(LIME.into()), 
+                    text_font.clone()
+                ));
+                parent.spawn((
+                    Text::new(""), 
+                    TextColor(AQUA.into()), 
+                    text_font.clone(), 
+                    ResponseIP
+                ));
             });
         });
 }


### PR DESCRIPTION
This fork specifies an arbitrary revision of the bevy repo for the lead up to the 0.15 release candidate cycle and updates `examples/window.rs` to account for changes in Bevy's `Text` functionality.

This is a pick at the current revision of bevy main, just to see what 0.15 broke and how to fix it.

I couldn't find any issues so far with the library itself on updating to bevy main, just this example.