### PR TITLE
access inner value T from a TypedResponse reference

### DIFF
--- a/src/typed.rs
+++ b/src/typed.rs
@@ -122,6 +122,11 @@ impl<T: for<'a> serde::Deserialize<'a>> TypedResponse<T> {
     pub fn into_inner(self) -> T {
         self.inner
     }
+
+    /// Access inner value T from a TypedResponse reference 
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
 }
 
 #[derive(Event, Debug, Clone, Deref)]

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -123,7 +123,7 @@ impl<T: for<'a> serde::Deserialize<'a>> TypedResponse<T> {
         self.inner
     }
 
-    /// Access inner value T from a TypedResponse reference 
+    /// Access inner value T from a TypedResponse reference
     pub fn inner(&self) -> &T {
         &self.inner
     }


### PR DESCRIPTION
bevy EventReader.read is returning a reference, only one into_inner() method is making access inner value difficult from a reference.
```rust
fn handle_response(mut events: EventReader<TypedResponse<ClientConnectionInfo>>) {
    for response in events.read() {
        info!("response received");
       // let client_info = response.into_inner();  // this line will panic
        let client_info = response.inner().clone();
         info!("{:?}", client_info);
    }
}
```

tried other way to make it work but none succeeded, if you has some suggestion please note me.