### PR TITLE
Update to 0.17.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ keywords = ["bevy", "http", "plugin", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = "0.16"
-bevy_derive = "0.16"
+bevy_app = "0.17.0-rc.1"
+bevy_derive = "0.17.0-rc.1"
 #bevy_hierarchy = "0.16.0"
-bevy_ecs = { version = "0.16", features = ["multi_threaded"] }
-bevy_tasks = "0.16"
-bevy_log = "0.16"
+bevy_ecs = { version = "0.17.0-rc.1", features = ["multi_threaded"] }
+bevy_tasks = "0.17.0-rc.1"
+bevy_log = "0.17.0-rc.1"
 
 crossbeam-channel = "0.5.11"
 ehttp = { version = "0.5.0", features = ["native-async", "json"] }
@@ -29,7 +29,7 @@ serde_json = "1.0"
 
 
 [dev-dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17.0-rc.1", default-features = false, features = [
     "animation",
     "bevy_asset",
     "bevy_gilrs",
@@ -40,11 +40,13 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_gltf",
     "bevy_render",
     "bevy_sprite",
+    "bevy_sprite_render",
     "bevy_text",
     "bevy_ui",
     "bevy_window",
     "bevy_log",
     "multi_threaded",
+    "zstd_rust",
     "png",
     "hdr",
     "x11",

--- a/README.md
+++ b/README.md
@@ -32,24 +32,24 @@ fn main() {
     app.run();
 }
 
-fn send_request(mut ev_request: EventWriter<TypedRequest<IpInfo>>) {
+fn send_request(mut ev_request: MessageWriter<TypedRequest<IpInfo>>) {
     if let Ok(request) = HttpClient::new()
         .get("https://api.ipify.org?format=json")
         .try_with_type::<IpInfo>()
     {
-        ev_request.send(request);
+        ev_request.write(request);
     }
 }
 
 /// consume TypedResponse<IpInfo> events
-fn handle_response(mut events: ResMut<Events<TypedResponse<IpInfo>>>) {
+fn handle_response(mut events: ResMut<Messages<TypedResponse<IpInfo>>>) {
     for response in events.drain() {
         let response: IpInfo = response.into_inner();
         println!("ip info: {:?}", response);
     }
 }
 
-fn handle_error(mut ev_error: EventReader<TypedResponseError<IpInfo>>) {
+fn handle_error(mut ev_error: MessageReader<TypedResponseError<IpInfo>>) {
     for error in ev_error.read() {
         println!("Error retrieving IP: {}", error.err);
     }

--- a/examples/ipinfo.rs
+++ b/examples/ipinfo.rs
@@ -13,7 +13,7 @@ fn main() {
         .run();
 }
 
-fn send_request(mut ev_request: EventWriter<HttpRequest>) {
+fn send_request(mut ev_request: MessageWriter<HttpRequest>) {
     match HttpClient::new().get("https://api.ipify.org").try_build() {
         Ok(request) => {
             ev_request.write(request);
@@ -24,13 +24,13 @@ fn send_request(mut ev_request: EventWriter<HttpRequest>) {
     }
 }
 
-fn handle_response(mut ev_resp: EventReader<HttpResponse>) {
+fn handle_response(mut ev_resp: MessageReader<HttpResponse>) {
     for response in ev_resp.read() {
         println!("response: {:?}", response.text());
     }
 }
 
-fn handle_error(mut ev_error: EventReader<HttpResponseError>) {
+fn handle_error(mut ev_error: MessageReader<HttpResponseError>) {
     for error in ev_error.read() {
         println!("Error retrieving IP: {}", error.err);
     }

--- a/examples/observer.rs
+++ b/examples/observer.rs
@@ -28,7 +28,7 @@ fn init_request(mut commands: Commands) {
 
 fn send_request(
     clients: Query<&HttpClient, With<IpRequestMarker>>,
-    mut ev_request: EventWriter<HttpRequest>,
+    mut ev_request: MessageWriter<HttpRequest>,
 ) {
     let requests: Vec<HttpRequest> = clients
         .iter()
@@ -44,10 +44,10 @@ fn send_request(
     ev_request.write_batch(requests);
 }
 
-fn handle_response(response: Trigger<HttpResponse>) {
-    println!("response: {:?}", response.text());
+fn handle_response(response: On<HttpObserved<HttpResponse>>) {
+    println!("response: {:?}", response.event().inner().text());
 }
 
-fn handle_error(error: Trigger<HttpResponseError>) {
-    println!("Error retrieving IP: {}", error.err);
+fn handle_error(error: On<HttpObserved<HttpResponseError>>) {
+    println!("Error retrieving IP: {}", error.event().inner().err);
 }

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -19,7 +19,7 @@ fn main() {
     app.run();
 }
 
-fn send_request(mut ev_request: EventWriter<TypedRequest<IpInfo>>) {
+fn send_request(mut ev_request: MessageWriter<TypedRequest<IpInfo>>) {
     match HttpClient::new()
         .get("https://api.ipify.org?format=json")
         .try_with_type::<IpInfo>()
@@ -34,14 +34,14 @@ fn send_request(mut ev_request: EventWriter<TypedRequest<IpInfo>>) {
 }
 
 /// consume TypedResponse<IpInfo> events
-fn handle_response(mut events: ResMut<Events<TypedResponse<IpInfo>>>) {
+fn handle_response(mut events: ResMut<Messages<TypedResponse<IpInfo>>>) {
     for response in events.drain() {
         let response: IpInfo = response.into_inner();
         println!("ip info: {:?}", response);
     }
 }
 
-fn handle_error(mut ev_error: EventReader<TypedResponseError<IpInfo>>) {
+fn handle_error(mut ev_error: MessageReader<TypedResponseError<IpInfo>>) {
     for error in ev_error.read() {
         println!("Error retrieving IP: {}", error.err);
     }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -82,7 +82,7 @@ fn setup(mut commands: Commands) {
 }
 
 fn send_request(
-    mut ev_request: EventWriter<HttpRequest>,
+    mut ev_request: MessageWriter<HttpRequest>,
     mut status_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
     mut ip_query: Query<&mut Text, (With<ResponseIP>, Without<ResponseText>)>,
 ) {
@@ -107,7 +107,7 @@ fn send_request(
 }
 
 fn handle_response(
-    mut ev_resp: EventReader<HttpResponse>,
+    mut ev_resp: MessageReader<HttpResponse>,
     mut status_query: Query<&mut Text, (With<ResponseText>, Without<ResponseIP>)>,
     mut ip_query: Query<&mut Text, (With<ResponseIP>, Without<ResponseText>)>,
 ) {
@@ -120,7 +120,7 @@ fn handle_response(
         }
     }
 }
-fn handle_error(mut ev_error: EventReader<HttpResponseError>) {
+fn handle_error(mut ev_error: MessageReader<HttpResponseError>) {
     for error in ev_error.read() {
         println!("Error retrieving IP: {}", error.err);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use bevy_tasks::IoTaskPool;
 use crossbeam_channel::{Receiver, Sender};
 use ehttp::{Headers, Request, Response};
 
-use crate::prelude::TypedRequest;
+use crate::{prelude::TypedRequest, typed::HttpObserved};
 
 pub mod prelude;
 mod typed;
@@ -864,7 +864,7 @@ fn handle_request(
                                 } else {
                                     bevy_log::error!("HttpResponse events resource not found");
                                 }
-                                world.trigger(HttpResponse(res));
+                                world.trigger(HttpObserved::new(entity, HttpResponse(res)));
                             }
                             Err(e) => {
                                 if let Some(mut events) =
@@ -874,7 +874,7 @@ fn handle_request(
                                 } else {
                                     bevy_log::error!("HttpResponseError events resource not found");
                                 }
-                                world.trigger(HttpResponseError::new(e.to_string()));
+                                world.trigger(HttpObserved::new(entity, HttpResponseError::new(e.to_string())));
                             }
                         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -874,7 +874,10 @@ fn handle_request(
                                 } else {
                                     bevy_log::error!("HttpResponseError events resource not found");
                                 }
-                                world.trigger(HttpObserved::new(entity, HttpResponseError::new(e.to_string())));
+                                world.trigger(HttpObserved::new(
+                                    entity,
+                                    HttpResponseError::new(e.to_string()),
+                                ));
                             }
                         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,7 +737,9 @@ impl HttpClient {
         since = "0.8.3",
         note = "Use `try_with_type()` instead for better error handling"
     )]
-    pub fn with_type<T: Send + Sync + 'static + for<'a> serde::Deserialize<'a>>(self) -> TypedRequest<T> {
+    pub fn with_type<T: Send + Sync + 'static + for<'a> serde::Deserialize<'a>>(
+        self,
+    ) -> TypedRequest<T> {
         TypedRequest::new(
             Request {
                 method: self.method.expect("method is required"),
@@ -872,8 +874,7 @@ fn handle_request(
                                 } else {
                                     bevy_log::error!("HttpResponseError events resource not found");
                                 }
-                                world
-                                    .trigger(HttpResponseError::new(e.to_string()));
+                                world.trigger(HttpResponseError::new(e.to_string()));
                             }
                         }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use super::{
-    typed::{HttpTypedRequestTrait, TypedRequest, TypedResponse, TypedResponseError},
+    typed::{HttpTypedRequestTrait, TypedRequest, TypedResponse, TypedResponseError, HttpObserved},
     HttpClient, HttpClientBuilderError, HttpClientPlugin, HttpClientSetting, HttpRequest,
     HttpResponse, HttpResponseError, JsonFallback, JsonSerializationError, RequestTask,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use super::{
-    typed::{HttpTypedRequestTrait, TypedRequest, TypedResponse, TypedResponseError, HttpObserved},
+    typed::{HttpObserved, HttpTypedRequestTrait, TypedRequest, TypedResponse, TypedResponseError},
     HttpClient, HttpClientBuilderError, HttpClientPlugin, HttpClientSetting, HttpRequest,
     HttpResponse, HttpResponseError, JsonFallback, JsonSerializationError, RequestTask,
 };

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -162,7 +162,10 @@ impl<T: Send + Sync + for<'a> serde::Deserialize<'a>> TypedResponse<T> {
 }
 
 #[derive(Message, Event, Debug, Clone, Deref)]
-pub struct TypedResponseError<T> where T: Send + Sync + 'static {
+pub struct TypedResponseError<T>
+where
+    T: Send + Sync + 'static,
+{
     #[deref]
     pub err: String,
     pub response: Option<Response>,
@@ -190,12 +193,9 @@ pub struct HttpObserved<T: Send + Sync + 'static> {
     pub event: T,
 }
 
-impl <T: Send + Sync + 'static> HttpObserved<T> {
+impl<T: Send + Sync + 'static> HttpObserved<T> {
     pub fn new(entity: Entity, event: T) -> Self {
-        HttpObserved {
-            entity,
-            event,
-        }
+        HttpObserved { entity, event }
     }
 
     pub fn inner(&self) -> &T {
@@ -249,7 +249,10 @@ fn handle_typed_request<T: for<'a> Deserialize<'a> + Send + Sync + Clone + 'stat
                                                 "TypedResponse events resource not found"
                                             );
                                         }
-                                        world.trigger(HttpObserved::new(entity, TypedResponse { inner }));
+                                        world.trigger(HttpObserved::new(
+                                            entity,
+                                            TypedResponse { inner },
+                                        ));
                                     }
                                     // deserialize error, send error + response
                                     Err(e) => {
@@ -266,9 +269,10 @@ fn handle_typed_request<T: for<'a> Deserialize<'a> + Send + Sync + Clone + 'stat
                                             );
                                         }
 
-                                        world.trigger(HttpObserved::new(entity,
+                                        world.trigger(HttpObserved::new(
+                                            entity,
                                             TypedResponseError::<T>::new(e.to_string())
-                                                .response(response)
+                                                .response(response),
                                         ));
                                     }
                                 }


### PR DESCRIPTION
Initial update to `0.17.0-rc.1`

Of note there's a change to `Event` which now splits it across `Event` (global observers) `EntityEvent` (observers attached to entities) and `Messages` (buffered events), so I had to introduce `HttpObserved<T>` with an `entity: Entity` field to be the wrapper for typed requests that are entity observers. Might be worth bikeshedding.

At this point there's a couple of known issues that haven't been addressed:

- [ ] the project wasn't compiling without a `zstd` feature enabled, I've not gone over release notes and discord conversations enough to know if this is a genuine need or just a dependency tree hiccup.
- [x] ~the observers example doesn't currently work, it's likely my `HttpObserved` logic needs another pass or two.~ 