### PR TITLE
Upgrade to Bevy 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.0] - 2026-05-27
+## [0.11.0] - 2026-06-20
 
 ### Changed
-- Upgrade to Bevy 0.19.0-rc.2
-- Updated all Bevy dependencies to 0.19.0-rc.2 compatible versions
-  - bevy_app: 0.19.0-rc.2
-  - bevy_derive: 0.19.0-rc.2
-  - bevy_ecs: 0.19.0-rc.2
-  - bevy_tasks: 0.19.0-rc.2
-  - bevy_log: 0.19.0-rc.2
+- Upgrade to Bevy 0.19.0
+- Updated all Bevy dependencies to 0.19.0 compatible versions
+  - bevy_app: 0.19.0
+  - bevy_derive: 0.19.0
+  - bevy_ecs: 0.19.0
+  - bevy_tasks: 0.19.0
+  - bevy_log: 0.19.0
 
 ### Fixed
 - Fixed `window` example for Bevy 0.19 UI rendering changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ keywords = ["bevy", "http", "plugin", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = "0.19.0-rc.2"
-bevy_derive = "0.19.0-rc.2"
-bevy_ecs = { version = "0.19.0-rc.2", features = ["multi_threaded"] }
-bevy_tasks = "0.19.0-rc.2"
-bevy_log = "0.19.0-rc.2"
+bevy_app = "0.19.0"
+bevy_derive = "0.19.0"
+bevy_ecs = { version = "0.19.0", features = ["multi_threaded"] }
+bevy_tasks = "0.19.0"
+bevy_log = "0.19.0"
 
 crossbeam-channel = "0.5.11"
 ehttp = { version = "0.5.0", features = ["native-async", "json"] }
@@ -28,7 +28,7 @@ serde_json = "1.0"
 
 
 [dev-dependencies]
-bevy = { version = "0.19.0-rc.2", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
     "bevy_asset",
     "bevy_gilrs",
     "bevy_scene",


### PR DESCRIPTION
Bevy 0.19.0 stable has been released on crates.io. This PR upgrades all Bevy dependencies from the previous release candidate (`0.19.0-rc.2`) to the stable `0.19.0`.

## Changes
- Updated all Bevy dependencies to `0.19.0`:
  - `bevy_app`, `bevy_derive`, `bevy_ecs`, `bevy_tasks`, `bevy_log`
- Updated `bevy` dev-dependency to `0.19.0`
- Updated CHANGELOG: bumped the `[0.11.0]` entry to reflect the Bevy 0.19.0 stable release

## Verification
- `cargo check` / `cargo check --examples` — pass
- `cargo test` — 23 doctests pass
- `cargo clippy --all-targets` — no warnings